### PR TITLE
Token properties should have the first letter as lower case.

### DIFF
--- a/Digirati.IIIF/Model/Types/Auth/Token.cs
+++ b/Digirati.IIIF/Model/Types/Auth/Token.cs
@@ -1,9 +1,16 @@
-﻿namespace Digirati.IIIF.Model.Types.Auth
+﻿using Newtonsoft.Json;
+
+namespace Digirati.IIIF.Model.Types.Auth
 {
     public class Token
     {
+        [JsonProperty(Order = 1, PropertyName = "accessToken")]
         public string AccessToken { get; set;}
+
+        [JsonProperty(Order = 2, PropertyName = "tokenType")]
         public const string TokenType = "Bearer";
+
+        [JsonProperty(Order = 3, PropertyName = "expiresIn")]
         public int ExpiresIn { get; set;}
     }
 }


### PR DESCRIPTION
Hi!

I'm experimenting with implementing the new Auth spec version 0.9, and from what I can read in the spec the token token properties should start with a lower case letter. This seems to be required by UV too.

Sebastian
