### PR TITLE
MaxWidth is always showing when using ImageServiceProfile

### DIFF
--- a/Digirati.IIIF/Model/Types/ImageApi/ImageServiceProfile.cs
+++ b/Digirati.IIIF/Model/Types/ImageApi/ImageServiceProfile.cs
@@ -15,6 +15,6 @@ namespace Digirati.IIIF.Model.Types.ImageApi
 
         // 2.1
         [JsonProperty(Order = 4, PropertyName = "maxWidth")]
-        public int MaxWidth { get; set; }
+        public int? MaxWidth { get; set; }
     }
 }


### PR DESCRIPTION
Since MaxWidth is of type int it has a default value of 0 and is showing
even when not wanted.
